### PR TITLE
Update Get-PwnedPassword to use anonymous endpoint

### DIFF
--- a/Get-PwnedPassword.ps1
+++ b/Get-PwnedPassword.ps1
@@ -1,14 +1,14 @@
 ﻿<#
 .SYNOPSIS
-Connects to the API at https://haveibeenpwned.com/ to see if a Password or Password hash has been found in a breach
+Connects to the API at https://api.pwnedpasswords.com/ to see if a Password or Password hash has been found in a breach
 
 .DESCRIPTION
-Connects to the API at https://haveibeenpwned.com/ to see if a Password or Password hash has been found in a breach
+Connects to the API at https://api.pwnedpasswords.com/ to see if a Password or Password hash has been found in a breach
 
 Troy Hunt @troyhunt has created an API which allows you to query if a Password has been found in a breach. 
 This is a simple function enabling you to query it
 
-IT IS NOT RECOMMENDED TO USE ACTIVE PASSWORDS WITH THIS SERVICE
+ONLY THE FIRST FIVE (5) CHARACTERS OF THE PASSWORD HASH ARE EVER SENT
 
 .PARAMETER Password
 The password to check as a secure string. If not supplied will be prompted
@@ -20,14 +20,14 @@ A SHA1 hash of the password to be checked
 $Password = Read-Host -AsSecureString
 Get-PwnedPassword -Password Password
 
-Connects to the API at https://haveibeenpwned.com/ and checks if a password has been found
+Connects to the API at https://api.pwnedpasswords.com/ and checks if a password has been found
 in a breach.
 
 
 .EXAMPLE
 Get-PwnedPassword -Hash 8be3c943b1609fffbfc51aad666d0a04adf83c9d
 
-Connects to the API at https://haveibeenpwned.com/ and checks if the SHA1 hash of 'Password' has been found
+Connects to the API at https://api.pwnedpasswords.com/ and checks if the SHA1 hash of 'Password' has been found
 in a breach.
 
 Don't run this. It has!!
@@ -35,14 +35,12 @@ Don't run this. It has!!
 .EXAMPLE
 Get-PwnedPassword
 
-Prompts for a Password and connects to the API at https://haveibeenpwned.com/ and checks if it has been found
+Prompts for a Password and connects to the API at https://api.pwnedpasswords.com/ and checks if it has been found
 in a breach.
 
 .NOTES
     AUTHOR : Rob Sewell @sqldbawithbeard https://sqldbawithabeard.com 
     DATE : 4th August 2017
-
-    IT IS NOT RECOMMENDED TO USE ACTIVE PASSWORDS WITH THIS SERVICE
 
     With many many thanks to Troy Hunt for creating this service
     You can find Troy on Twitter @TroyHunt
@@ -78,11 +76,21 @@ function Get-PwnedPassword {
         switch ($PSCmdlet.ParameterSetName) {
             'Password' {
                 $Pass = (New-Object PSCredential "user", $Password).GetNetworkCredential().Password
-                $URL = 'https://haveibeenpwned.com/api/v2/pwnedpassword/' + $Pass
+                $StringBuilder = New-Object System.Text.StringBuilder
+                [System.Security.Cryptography.HashAlgorithm]::Create("SHA1").ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Pass))|% { 
+                    [Void]$StringBuilder.Append($_.ToString("x2")) 
+                }
+                $sha1 = $StringBuilder.ToString()
+                $sha1Prefix = $sha1.Substring(0, 5)
+                $sha1Suffix = $sha1.Substring(5)
+
+                $URL = 'https://api.pwnedpasswords.com/range/' + $sha1Prefix
                 break
             }
             'Hash' {
-                $URL = 'https://haveibeenpwned.com/api/v2/pwnedpassword/' + $Hash
+                $sha1Prefix = $Hash.Substring(0, 5)
+                $sha1Suffix = $Hash.Substring(5)
+                $URL = 'https://api.pwnedpasswords.com/range/' + $sha1Prefix
                 break
             }
             default {
@@ -109,7 +117,13 @@ function Get-PwnedPassword {
             break
         }
         if ($Response.StatusCode -eq '200') {
-            Write-Warning -Message "Oh No! - Password has been pwned - Change it NOW! `nYou should sign up for free at https://haveibeenpwned.com/ to be notified when your account is in a breach"
+            if ($Response.Content.Contains($sha1Suffix.ToUpper())) {
+                # Password has been pwned
+                Write-Warning -Message "Oh No! - Password has been pwned - Change it NOW! `nYou should sign up for free at https://haveibeenpwned.com/ to be notified when your account is in a breach"
+            }
+            else {
+                Write-Output  "Hurrah! - No Password found - Congratulations this password has not been pwned. `nYou should still sign up for free at https://haveibeenpwned.com/ to be notified when your account is in a breach"
+            }
         }
     }
     end {
@@ -123,7 +137,7 @@ function Get-PwnedPassword {
 
 .AUTHOR Rob Sewell @sqldbawithbeard https://sqldbawithabeard.com 
 
-.DESCRIPTION Connects to the API at https://haveibeenpwned.com/ to see if a Password or Password hash has been found in a breach. Troy Hunt @troyhunt has created an API which allows you to query if a Password has been found in a breach. This is a simple function enabling you to query it
+.DESCRIPTION Connects to the API at https://api.pwnedpasswords.com/ to see if a Password or Password hash has been found in a breach. Troy Hunt @troyhunt has created an API which allows you to query if a Password has been found in a breach. This is a simple function enabling you to query it
       
 .COMPANYNAME Sewells Consulting
 


### PR DESCRIPTION
 - Troy of Have I Been Pwned? has disabled the ability to search by password. Current calls to ```https://haveibeenpwned.com/api/v2/pwnedpassword/``` are probably failing. This PR changes the pwned password check to use the [anonymous endpoint Troy has set up](https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByRange).
- This PR maintains the ability to pass either a password or a hash (specified by command line switch).
- Rate limiting should no longer be a concern as there is no rate limiting on the new API.
- This PR also removes the ```IT IS NOT RECOMMENDED TO USE ACTIVE PASSWORDS WITH THIS SERVICE``` warning since only the first five characters of a SHA1 hash are now sent. The API responds with ~500 hash suffixes that the requesting client can check against.